### PR TITLE
feat!: Neovim 0.12+ rewrite (perf, zen state, statusline)

### DIFF
--- a/nvim_lite/init.lua
+++ b/nvim_lite/init.lua
@@ -1,4 +1,4 @@
--- === Neovim 0.11+ Configuration ===
+-- === Neovim 0.12+ Configuration ===
 
 -- === Localized References ===
 local opt      = vim.opt
@@ -6,121 +6,135 @@ local cmd      = vim.cmd
 local fn       = vim.fn
 local api      = vim.api
 local kset     = vim.keymap
-local lset     = vim.opt_local
 local vset     = vim.v
 local bo       = vim.bo
 local g        = vim.g
 local defer_fn = vim.defer_fn
 local schedule = vim.schedule
 local uv       = vim.uv
+-- Localized to avoid repeated global-chain lookups on hot-path events.
+local ts_get_parser = vim.treesitter.get_parser
+
+-- === Shutdown Flag ===
+-- Set in VimLeavePre before timers are closed. Every timer start site checks
+-- this flag so that in-flight schedule() callbacks cannot restart a closed
+-- libuv handle (which would raise a EBADF-class error in the log).
+local _shutting_down = false
 
 -- === Static Timer Allocation (prevents GC churn) ===
-local Timers = {
-  cursor = uv.new_timer(),
-  redraw = uv.new_timer(),
-  gc     = uv.new_timer(),
-}
+-- All three timers are localized immediately; Timers table exists only for
+-- unified teardown in VimLeavePre.
+local cursor_timer = uv.new_timer()
+local redraw_timer = uv.new_timer()
+local gc_timer     = uv.new_timer()
+local Timers = { cursor = cursor_timer, redraw = redraw_timer, gc = gc_timer }
 
 -- === Batch Plugin & Provider Disabling ===
-local disabled_plugins = {
-  'matchparen', 'matchit',
-  'gzip', 'tar', 'tarPlugin', 'zip', 'zipPlugin',
-  'getscript', 'getscriptPlugin', 'vimball', 'vimballPlugin',
-  'rrhelper', '2html_plugin', 'logiPat',
-  'netrw', 'netrwPlugin', 'netrwSettings', 'netrwFileHandlers',
-  'tutor',
+-- Unified data table: string keys are compile-time constants, so there are
+-- zero runtime concatenations at startup (vs. 16 in the loop-based approach).
+-- Comments mark each group for future maintainers.
+local _g_flags = {
+  -- Slow / unused built-in plugins (sentinel = 1)
+  loaded_matchparen       = 1,
+  loaded_matchit          = 1,
+  loaded_gzip             = 1,
+  loaded_tar              = 1,
+  loaded_tarPlugin        = 1,
+  loaded_zip              = 1,
+  loaded_zipPlugin        = 1,
+  loaded_getscript        = 1,
+  loaded_getscriptPlugin  = 1,
+  loaded_vimball          = 1,
+  loaded_vimballPlugin    = 1,
+  loaded_rrhelper         = 1,
+  loaded_tutor            = 1,
+  -- External providers unused; 0 signals "provider absent" to Neovim.
+  loaded_python_provider  = 0,
+  loaded_python3_provider = 0,
+  loaded_node_provider    = 0,
+  loaded_perl_provider    = 0,
+  loaded_ruby_provider    = 0,
 }
-for _, plugin in ipairs(disabled_plugins) do
-  g['loaded_' .. plugin] = 1
-end
-
-local disabled_providers = { 'python', 'python3', 'node', 'perl', 'ruby' }
-for _, provider in ipairs(disabled_providers) do
-  g['loaded_' .. provider .. '_provider'] = 0
-end
+for k, v in pairs(_g_flags) do g[k] = v end
 
 -- === Options ===
--- Performance
-opt.mouse         = ""
-opt.updatetime    = 250         
-opt.synmaxcol     = 200
-opt.redrawtime    = 1000        
-                                
-opt.maxmempattern = 2000
-opt.cursorline    = false
-opt.cursorcolumn  = false
-
--- UI
-opt.number        = true
-opt.scrolloff     = 10
-opt.sidescrolloff = 8
-opt.showmode      = false
-opt.modeline      = false
-opt.undofile      = true
-opt.swapfile      = false
-opt.backup        = false
-opt.writebackup   = false
-
-opt.backupskip:append({ "/tmp/*", "/private/tmp/*" })
-
--- Timing
-opt.timeoutlen    = 300
-opt.ttimeoutlen   = 40
-opt.keymodel      = ""
-
--- Encoding
-opt.fileencodings = "utf-8"
-
--- Indentation
-opt.expandtab   = true
-opt.shiftwidth  = 2
-opt.tabstop     = 2
-opt.softtabstop = 2
-opt.smartindent = true
-opt.autoindent  = true
-
--- Search
-opt.ignorecase = true
-opt.smartcase  = true
-opt.hlsearch   = true
-opt.incsearch  = true
-
--- Interface
-opt.cmdheight   = 0
-opt.completeopt = { "menuone", "noinsert", "noselect" }  
-opt.splitright  = true
-opt.splitbelow  = true
-
--- Memory
-opt.history    = 2000
-opt.undolevels = 200
-
--- Colors
-opt.termguicolors = true
-
--- === Window-local Defaults ===
-local win_defaults = {
-  relativenumber = false,
-  wrap           = false,
-  linebreak      = false,
-  breakindent    = false,
-  signcolumn     = "yes:1",
+-- Applied in a single table-driven loop; avoids 34 individual vim.opt
+-- metatable dispatches and makes future auditing straightforward.
+local _opts = {
+  -- Performance
+  mouse         = "",
+  updatetime    = 250,
+  synmaxcol     = 200,
+  redrawtime    = 1000,
+  maxmempattern = 2000,
+  cursorline    = false,
+  cursorcolumn  = false,
+  -- UI
+  number        = true,
+  scrolloff     = 10,
+  sidescrolloff = 8,
+  showmode      = false,
+  modeline      = false,
+  undofile      = true,
+  swapfile      = false,
+  backup        = false,
+  writebackup   = false,
+  pumheight     = 10,       -- cap completion menu height; prevents layout thrash
+  splitkeep     = "screen", -- reduce layout shifts on split (0.9+)
+  jumpoptions   = "stack",  -- browser-history-style jump list
+  -- Timing
+  timeoutlen    = 300,
+  ttimeoutlen   = 40,
+  keymodel      = "",
+  -- Encoding (ucs-bom prefix handles BOM detection; no behaviour change for UTF-8)
+  fileencodings = "ucs-bom,utf-8,default,latin1",
+  fileformats   = "unix,dos,mac",
+  -- Indentation
+  expandtab     = true,
+  shiftwidth    = 2,
+  tabstop       = 2,
+  softtabstop   = 2,
+  smartindent   = true,
+  autoindent    = true,
+  -- Search
+  ignorecase    = true,
+  smartcase     = true,
+  hlsearch      = true,
+  incsearch     = true,
+  -- Interface
+  cmdheight     = 0,
+  splitright    = true,
+  splitbelow    = true,
+  termguicolors = true,
+  -- History / memory
+  history       = 2000,
+  undolevels    = 1000,
 }
-local function apply_win_defaults(win)
-  local wo = vim.wo[win] or vim.wo
-  for k, v in pairs(win_defaults) do wo[k] = v end
-end
-apply_win_defaults(0)  -- seed the initial window
+for k, v in pairs(_opts) do opt[k] = v end
+
+-- Append / list operations cannot live in the batch table.
+opt.backupskip:append({ "/tmp/*", "/private/tmp/*" })
+opt.completeopt = { "menuone", "noinsert", "noselect" }
+opt.shortmess:append("sI")   -- suppress intro screen and search-wrap messages
 
 -- === Disable LSP Logging ===
-pcall(vim.lsp.set_log_level, "OFF")
+-- vim.lsp.set_log_level() was deprecated in 0.12. Replacement: vim.lsp.log.set_level().
+pcall(vim.lsp.log.set_level, "OFF")
 
 -- === Highlight Groups ===
+-- Branches on vim.o.background so colours remain legible on light themes.
+-- The ColorScheme callback is deferred by one schedule() tick to let the theme
+-- finish applying before we override specific groups.
 local function apply_highlights()
-  local hl_defs = {
+  local is_dark = vim.o.background ~= "light"
+  local hl_defs = is_dark and {
     TabLine     = { fg = '#808080', bg = '#1e1e1e' },
     TabLineSel  = { fg = '#ffffff', bg = '#3a3a3a', bold = true },
     TabLineFill = { fg = 'NONE',    bg = '#1e1e1e' },
+  } or {
+    TabLine     = { fg = '#555555', bg = '#d4d4d4' },
+    TabLineSel  = { fg = '#000000', bg = '#ffffff', bold = true },
+    TabLineFill = { fg = 'NONE',    bg = '#d4d4d4' },
   }
   for name, opts in pairs(hl_defs) do
     api.nvim_set_hl(0, name, opts)
@@ -134,24 +148,31 @@ local autocmd = api.nvim_create_autocmd
 autocmd("ColorScheme", {
   group    = augroup("HighlightOverrides", { clear = true }),
   pattern  = "*",
-  callback = apply_highlights,
+  -- Defer: some colorscheme plugins emit multiple ColorScheme events in one
+  -- load sequence; the schedule() tick ensures our overrides run last.
+  callback = function() schedule(apply_highlights) end,
 })
 
 -- === Cache System ===
--- Uses an O(1) _size counter instead of an O(n) pairs-count on every set().
--- Holes from _remove_key are avoided: the order list is only compacted
--- in bulk via _compact(), never by nil-ing individual slots.
+-- Design notes:
+--   * _order_len tracks the logical length of the order array explicitly.
+--     Never use # on self.order because _remove_key creates interior nil holes,
+--     making # return an undefined "border" value in Lua. This was a silent
+--     correctness bug in the original implementation.
+--   * _compact() rebuilds order and key_index in-place (no new table allocs).
+--   * invalidate() is the public API; _remove_key() remains internal.
 local Cache = {}
 Cache.__index = Cache
 
 function Cache:new(max_size, ttl)
   return setmetatable({
-    data      = {},
-    order     = {},
-    key_index = {},
-    _size     = 0,
-    max_size  = max_size or 100,
-    ttl       = ttl or 1000,
+    data       = {},
+    order      = {},
+    key_index  = {},
+    _size      = 0,
+    _order_len = 0,   -- explicit length; never trust # on the sparse order array
+    max_size   = max_size or 100,
+    ttl        = ttl  or 1000,
   }, self)
 end
 
@@ -165,18 +186,23 @@ function Cache:get(key)
   return entry.value
 end
 
--- Internal: removes from data + key_index but leaves a nil slot in order.
--- The order array is compacted in bulk by _compact() to avoid O(n) per removal.
+-- Internal: removes from data + key_index, leaves a nil hole in order.
+-- Holes are compacted in bulk by _compact() to avoid O(n) work per removal.
 function Cache:_remove_key(key)
   if not self.data[key] then return end
   self.data[key] = nil
-  self._size = self._size - 1
+  self._size     = self._size - 1
   local idx = self.key_index[key]
   if idx then
-    self.order[idx] = nil   -- sparse hole; _compact() cleans these up
+    self.order[idx]     = nil  -- sparse hole; length tracked via _order_len
     self.key_index[key] = nil
+    -- Do NOT decrement _order_len here: the slot is a hole inside the array,
+    -- not a removal from the end. _compact() will rebuild the true length.
   end
 end
+
+-- Public alias; external callers must not depend on the internal name.
+function Cache:invalidate(key) self:_remove_key(key) end
 
 function Cache:set(key, value)
   local now = uv.now()
@@ -189,7 +215,7 @@ function Cache:set(key, value)
 
   -- Evict oldest live entry when at capacity (O(n) scan only on overflow).
   if self._size >= self.max_size then
-    for i = 1, #self.order do
+    for i = 1, self._order_len do
       local old_key = self.order[i]
       if old_key then
         self:_remove_key(old_key)
@@ -198,36 +224,43 @@ function Cache:set(key, value)
     end
   end
 
-  -- Compact the order array if it has grown too sparse.
-  if #self.order > self.max_size * 2 then
+  -- Compact when the order array has grown more than 2x the live entry count.
+  if self._order_len > self.max_size * 2 then
     self:_compact()
   end
 
-  self.data[key]      = { value = value, time = now }
-  self._size          = self._size + 1
-  self.order[#self.order + 1] = key
-  self.key_index[key] = #self.order
+  self.data[key]              = { value = value, time = now }
+  self._size                  = self._size + 1
+  self._order_len             = self._order_len + 1
+  self.order[self._order_len] = key
+  self.key_index[key]         = self._order_len
 end
 
+-- Rebuild order and key_index in-place: reuses existing tables, clears
+-- trailing stale slots, updates _order_len. Zero new table allocations.
 function Cache:_compact()
-  local new_order = {}
-  local new_index = {}
-  for i = 1, #self.order do
-    local key = self.order[i]
+  local order     = self.order
+  local key_index = self.key_index
+  local write = 0
+  for i = 1, self._order_len do
+    local key = order[i]
     if key and self.data[key] then
-      new_order[#new_order + 1] = key
-      new_index[key] = #new_order
+      write          = write + 1
+      order[write]   = key
+      key_index[key] = write
     end
   end
-  self.order     = new_order
-  self.key_index = new_index
+  -- Clear stale trailing slots without allocating a replacement array.
+  for i = write + 1, self._order_len do order[i] = nil end
+  self._order_len = write
 end
 
 function Cache:clear()
-  self.data      = {}
-  self.order     = {}
-  self.key_index = {}
-  self._size     = 0
+  self.data       = {}
+  self.order      = {}
+  self.key_index  = {}
+  self._size      = 0
+  self._order_len = 0
 end
 
 function Cache:gc()
@@ -238,189 +271,285 @@ function Cache:gc()
       expired[#expired + 1] = key
     end
   end
-  for _, key in ipairs(expired) do
-    self:_remove_key(key)
-  end
-  if #expired > 0 then
-    self:_compact()
-  end
+  for _, key in ipairs(expired) do self:_remove_key(key) end
+  if #expired > 0 then self:_compact() end
 end
 
 -- === Global Caches ===
 local search_cache = Cache:new(10, 500)
 local syntax_cache = Cache:new(20, 2000)
+local tab_cache    = Cache:new(5,  200)
 
--- === Redraw Scheduler (timer reuse) ===
-local RedrawScheduler = {
-  pending = {},
-  delay   = 16,
-}
+-- Hoisted to module scope: reused on every search_info cache miss.
+-- Allocating this table inside search_info would cost one allocation per miss.
+local _searchcount_opts = { maxcount = 0, timeout = 100 }
 
-function RedrawScheduler:schedule(redraw_type)
-  self.pending[redraw_type] = true
-  if Timers.redraw:is_active() then return end
+-- === Redraw Scheduler ===
+-- Uses a bitmask integer instead of a pending table. Eliminates the table
+-- entirely; bitwise OR is the accumulation operation. Adding a new redraw
+-- type requires only a new constant and one branch in _do_redraw.
+--
+-- Neovim embeds LuaJIT (Lua 5.1): the Lua 5.4 bitwise operators & | are not
+-- available. Use LuaJIT's bit library (bit.band / bit.bor) instead.
+local bit_band = bit.band
+local bit_bor  = bit.bor
 
-  Timers.redraw:start(self.delay, 0, function()
-    schedule(function()
-      -- Snapshot and clear pending before issuing redraws.
-      local needs_tabline = self.pending.tabline
-      local needs_status  = self.pending.status
-      local needs_full    = self.pending.full
-      -- Clear in-place: avoids allocating a new table every 16ms dispatch cycle.
-      self.pending.tabline = nil
-      self.pending.status  = nil
-      self.pending.full    = nil
+local REDRAW_TABLINE = 1
+local REDRAW_STATUS  = 2
+local REDRAW_FULL    = 4
 
-      if needs_full then
-        cmd("redraw")
-      elseif needs_tabline and needs_status then
-        cmd("redrawtabline")
-        cmd("redrawstatus")
-      elseif needs_tabline then
-        cmd("redrawtabline")
-      elseif needs_status then
-        cmd("redrawstatus")
-      end
-    end)
-  end)
+local _redraw_pending = 0
+local _redraw_delay   = 16   -- ms; ~one frame at 60 Hz
+
+local function _do_redraw()
+  local p         = _redraw_pending
+  _redraw_pending = 0
+  if p == 0 then return end
+  if bit_band(p, REDRAW_FULL) ~= 0 then
+    cmd("redraw")
+  elseif bit_band(p, REDRAW_TABLINE) ~= 0 and bit_band(p, REDRAW_STATUS) ~= 0 then
+    cmd("redrawtabline")
+    cmd("redrawstatus")
+  elseif bit_band(p, REDRAW_TABLINE) ~= 0 then
+    cmd("redrawtabline")
+  elseif bit_band(p, REDRAW_STATUS) ~= 0 then
+    cmd("redrawstatus")
+  end
 end
 
--- === Syntax Settings ===
+local function _redraw_timer_cb() schedule(_do_redraw) end
+
+-- schedule_redraw() replaces RedrawScheduler:schedule(). Plain function;
+-- no self lookup, no method dispatch overhead.
+local function schedule_redraw(flags)
+  _redraw_pending = bit_bor(_redraw_pending, flags)
+  if _shutting_down or redraw_timer:is_active() then return end
+  redraw_timer:start(_redraw_delay, 0, _redraw_timer_cb)
+end
+
+-- === Syntax FileType Handler ===
 -- Hash sets give O(1) lookup vs O(n) tbl_contains on every FileType event.
-local syntax_fast  = { c=true, cpp=true, java=true, python=true, lua=true, javascript=true, typescript=true }
-local syntax_heavy = { json=true, yaml=true, markdown=true, text=true, plaintex=true }
+-- Expanded to cover modern filetypes absent from the original sets.
+local syntax_fast = {
+  c=true, cpp=true, h=true, hpp=true,
+  java=true, python=true, lua=true,
+  javascript=true, typescript=true, tsx=true, jsx=true,
+  go=true, rust=true, zig=true,
+  ruby=true, php=true, swift=true,
+}
+local syntax_heavy = {
+  json=true, yaml=true, toml=true,
+  markdown=true, text=true, plaintex=true,
+  html=true, css=true, scss=true, xml=true,
+}
 
 autocmd("FileType", {
   group    = augroup("PerfFileTypeHandler", { clear = true }),
   pattern  = "*",
   callback = function(args)
-    local ft        = args.match
-    local cache_key = ft .. "_" .. args.buf
+    local ft  = args.match
+    local buf = args.buf
+    -- \0 as key separator: cannot appear in a filetype string, avoids
+    -- ambiguous concatenation (e.g. ft="lua" buf=5 vs ft="lua5" buf="").
+    local cache_key = ft .. "\0" .. buf
     if syntax_cache:get(cache_key) then return end
 
     if syntax_fast[ft] then
-      cmd("syntax sync minlines=200 maxlines=500")
-    elseif syntax_heavy[ft] and fn.line("$") > 1000 then
-      lset.foldmethod = "manual"
-      lset.synmaxcol  = 300
-      lset.wrap       = true
-      lset.linebreak  = true
-      lset.breakindent = true
+      -- pcall guard: get_parser() returns nil on 0.12+ but could throw on
+      -- older patch levels loaded via a version manager.
+      local ok, parser = pcall(ts_get_parser, buf, ft)
+      if not (ok and parser) then
+        cmd("syntax sync minlines=200 maxlines=500")
+      end
+    elseif syntax_heavy[ft] then
+      -- nvim_buf_line_count: native API equivalent of fn.line("$");
+      -- avoids the vimscript bridge on every FileType event.
+      if api.nvim_buf_line_count(buf) > 1000 then
+        api.nvim_set_option_value("foldmethod", "manual", { win = 0 })
+        -- Tighten synmaxcol for large heavy files (performance). The original
+        -- set it to 300, wider than the global 200 — incorrect direction.
+        api.nvim_set_option_value("synmaxcol",   120,  { buf = buf })
+        api.nvim_set_option_value("wrap",        true, { win = 0 })
+        api.nvim_set_option_value("linebreak",   true, { win = 0 })
+        api.nvim_set_option_value("breakindent", true, { win = 0 })
+      end
     end
 
     syntax_cache:set(cache_key, true)
   end,
 })
 
--- === Apply Window Defaults to Every New Window ===
-autocmd({ "WinNew" }, {
-  group    = augroup("WinDefaultsApply", { clear = true }),
+-- Evict syntax cache entries when a buffer is deleted or wiped.
+-- BufDelete covers :bdelete; BufWipeout covers :bwipeout and plugin-created
+-- scratch buffers, both of which can immediately reuse the buffer number and
+-- would get a false cache hit on the next FileType event.
+autocmd({ "BufDelete", "BufWipeout" }, {
+  group    = augroup("SyntaxCacheEvict", { clear = true }),
   callback = function(args)
-    -- args.match is empty for WinNew; apply to the current window.
-    schedule(function()
-      apply_win_defaults(api.nvim_get_current_win())
-    end)
+    local buf_suffix = "\0" .. tostring(args.buf)
+    local to_del = {}
+    for key in pairs(syntax_cache.data) do
+      if key:sub(-#buf_suffix) == buf_suffix then
+        to_del[#to_del + 1] = key
+      end
+    end
+    for _, k in ipairs(to_del) do syntax_cache:invalidate(k) end
+  end,
+})
+
+-- === Window Setup ===
+-- Unified handler: applies base window defaults, then layers zen settings on
+-- top if zen is active. Replaces the two separate WinNew handlers that
+-- previously could conflict with each other.
+local win_defaults = {
+  relativenumber = false,
+  wrap           = false,
+  linebreak      = false,
+  breakindent    = false,
+  signcolumn     = "yes:1",
+}
+
+local function setup_window(win)
+  if not api.nvim_win_is_valid(win) then return end  -- guard against close race
+  local wopts = { win = win }
+  for k, v in pairs(win_defaults) do
+    api.nvim_set_option_value(k, v, wopts)
+  end
+  -- If zen is active, layer its per-window overrides on top of base defaults.
+  if _G.zen_mode and _G.zen_mode.active then
+    for _, opt_name in ipairs(_G.zen_mode.window_opts) do
+      local val = _G.zen_mode.config[opt_name]
+      if val ~= nil then
+        api.nvim_set_option_value(opt_name, val, wopts)
+      end
+    end
+  end
+end
+
+setup_window(api.nvim_get_current_win())  -- seed the initial window
+
+autocmd("WinNew", {
+  group    = augroup("WinSetup", { clear = true }),
+  callback = function()
+    -- schedule(): WinNew fires before the window is fully initialised.
+    schedule(function() setup_window(api.nvim_get_current_win()) end)
   end,
 })
 
 -- === Arrow Key Disable ===
-local nop_opts = { desc = "Arrow Disabled", noremap = true, silent = true }
-for _, mode in ipairs({ "n", "v" }) do
-  for _, arrow in ipairs({ "<Up>", "<Down>", "<Left>", "<Right>" }) do
+-- Extended to insert and operator-pending modes: trains consistent hjkl
+-- habits without leaving an escape hatch in insert mode.
+local nop_opts   = { desc = "Arrow Disabled", noremap = true, silent = true }
+local nop_modes  = { "n", "v", "i", "o" }
+local nop_arrows = { "<Up>", "<Down>", "<Left>", "<Right>" }
+for _, mode in ipairs(nop_modes) do
+  for _, arrow in ipairs(nop_arrows) do
     kset.set(mode, arrow, "<Nop>", nop_opts)
   end
 end
 
--- === Whitespace & Tab Trimmer (single buffer pass) ===
+-- === Whitespace & Tab Trimmer ===
 -- Both transformations share one nvim_buf_get_lines call and accumulate
--- changed lines into a single batch rather than per-line nvim_buf_set_lines
--- calls (which would create many undo entries).
+-- changed lines into a single batch to avoid many undo entries.
+--
+-- All scratch state and the flush helper are at module scope:
+--   * Eliminates one closure allocation + upvalue cells per BufWritePre call.
+--   * _cb_run_lines is reused across calls; a snapshot is taken per-run before
+--     passing to nvim_buf_set_lines.
 local trim_pattern = "^(.-)%s*$"
 local tab_pattern  = "\t"
+
+local _cb_ranges     = {}   -- { {start_0idx, end_0idx_excl, lines_snapshot} }
+local _cb_ranges_len = 0
+local _cb_run_lines  = {}   -- accumulator for the current contiguous run
+local _cb_run_len    = 0
+local _cb_run_start  = nil  -- 0-indexed inclusive start of current run, or nil
+
+local function _cb_flush(end_excl)
+  if not _cb_run_start then return end
+  -- Snapshot the current run: _cb_run_lines will be reused for the next run.
+  local snapshot = {}
+  for i = 1, _cb_run_len do snapshot[i] = _cb_run_lines[i] end
+  _cb_ranges_len             = _cb_ranges_len + 1
+  _cb_ranges[_cb_ranges_len] = { _cb_run_start, end_excl, snapshot }
+  _cb_run_start = nil
+  _cb_run_len   = 0
+end
+
+local MAX_CLEAN_LINES = 50000   -- skip the pass on very large files
 
 local function clean_buffer()
   if not bo.modifiable then return end
   if not bo.modified   then return end
-
-  
   local bt = bo.buftype
   if bt ~= "" and bt ~= "acwrite" then return end
+  if not bo.expandtab then return end   -- don't mangle intentional tabs
 
-  if not bo.expandtab then return end  -- don't mangle intentional tabs
+  local bufnr = api.nvim_get_current_buf()
+  if api.nvim_buf_line_count(bufnr) > MAX_CLEAN_LINES then return end
+
   local tab_repl = string.rep(" ", bo.tabstop)
+  local lines    = api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
-  local bufnr         = api.nvim_get_current_buf()
-  local lines         = api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  local changed_ranges = {}  -- { {start, end, lines} }
-
-  local run_start = nil
-  local run_lines = {}
-
-  -- end_excl: 0-indexed exclusive end for nvim_buf_set_lines (passed directly by callers).
-  local function flush_run(end_excl)
-    if run_start then
-      changed_ranges[#changed_ranges + 1] = { run_start, end_excl, run_lines }
-      run_start = nil
-      run_lines = {}
-    end
-  end
+  -- Reset scratch state (no allocation).
+  _cb_ranges_len = 0
+  _cb_run_start  = nil
+  _cb_run_len    = 0
 
   for i, l in ipairs(lines) do
     local new_line = l:match(trim_pattern)
+    -- find() guard before gsub(): on files where most lines are tab-free,
+    -- skipping gsub() avoids one string operation per tab-free line.
     if new_line:find(tab_pattern, 1, true) then
       new_line = new_line:gsub(tab_pattern, tab_repl)
     end
     if new_line ~= l then
-      if not run_start then
-        run_start = i - 1  -- convert to 0-indexed inclusive start
-        run_lines = {}
-      end
-      run_lines[#run_lines + 1] = new_line
+      if not _cb_run_start then _cb_run_start = i - 1 end  -- convert to 0-indexed
+      _cb_run_len                = _cb_run_len + 1
+      _cb_run_lines[_cb_run_len] = new_line
     else
-      -- Line i is unchanged; the run (if any) ended at line i-1.
-      -- 0-indexed exclusive end = i-1 (the unchanged line's 0-idx position).
-      flush_run(i - 1)
+      _cb_flush(i - 1)  -- 0-indexed exclusive end = unchanged line's 0-idx position
     end
   end
-  -- Flush any trailing run; 0-indexed exclusive end = #lines (one past last line).
-  flush_run(#lines)
+  _cb_flush(#lines)   -- flush trailing run; exclusive end = one past last line
 
-  for _, range in ipairs(changed_ranges) do
-    api.nvim_buf_set_lines(bufnr, range[1], range[2], false, range[3])
+  for i = 1, _cb_ranges_len do
+    local r = _cb_ranges[i]
+    api.nvim_buf_set_lines(bufnr, r[1], r[2], false, r[3])
   end
 end
 
 local save_group = augroup("SaveHooks", { clear = true })
 autocmd("BufWritePre", {
-  group    = save_group,
-  pattern  = { "*.lua", "*.c", "*.cpp", "*.py", "*.js", "*.java" },
+  group   = save_group,
+  -- Extended to cover modern filetypes absent from the original pattern list.
+  pattern = {
+    "*.lua",
+    "*.c", "*.h", "*.cpp", "*.hpp",
+    "*.py",
+    "*.js", "*.ts", "*.tsx", "*.jsx",
+    "*.java",
+    "*.go",
+    "*.rs",
+    "*.sh", "*.bash",
+    "*.toml", "*.yaml", "*.yml",
+  },
   callback = clean_buffer,
 })
 
--- === Deferred Initialization ===
-autocmd("VimEnter", {
-  once     = true,
-  callback = function()
-    defer_fn(function()
-      opt.shadafile = ""
-      opt.shada     = "!,'100,<50,s10,h"
-      local shada_path = fn.stdpath("data") .. "/shada/main.shada"
-      if fn.filereadable(shada_path) == 1 then
-        pcall(cmd, "silent! rshada")
-      end
-      opt.clipboard = "unnamedplus"
-    end, 100)
-  end,
-})
-
 -- === Search Counter ===
+-- Cache key includes the cursor line so searchcount's current-match index is
+-- always accurate. The original keyed only on the pattern, returning a stale
+-- "3/10" after cursor movement within the same search session.
 _G.search_info = function()
   if vset.hlsearch == 0 then return "" end
-  local key    = fn.getreg("/")
-  local cached = search_cache:get(key)
+  local pattern = fn.getreg("/")
+  local line    = api.nvim_win_get_cursor(0)[1]  -- 1-indexed cursor line
+  local key     = pattern .. "\0" .. line         -- \0 cannot appear in a pattern
+  local cached  = search_cache:get(key)
   if cached then return cached end
 
-  local ok, s  = pcall(fn.searchcount, { maxcount = 0, timeout = 100 })
+  local ok, s  = pcall(fn.searchcount, _searchcount_opts)
   local result = ""
   if ok and s and s.total and s.total > 0 then
     result = string.format(" %d/%d", s.current or 0, s.total)
@@ -430,37 +559,91 @@ _G.search_info = function()
 end
 
 -- === Macro Recording Indicator ===
-local macro_reg = ""
+-- _macro_display is pre-computed once on RecordingEnter so that the hot
+-- statusline render path performs zero string allocations per redraw.
+local _macro_display = ""
 
-_G.macro_info = function()
-  return macro_reg ~= "" and (" REC @" .. macro_reg .. " ") or ""
-end
+_G.macro_info = function() return _macro_display end
 
 local macro_group = augroup("MacroStatusline", { clear = true })
 autocmd("RecordingEnter", {
   group    = macro_group,
   callback = function()
-    macro_reg = fn.reg_recording()
-    RedrawScheduler:schedule("status")
+    -- Concatenation happens once per session, not once per statusline render.
+    _macro_display = " REC @" .. fn.reg_recording() .. " "
+    schedule_redraw(REDRAW_STATUS)
   end,
 })
 autocmd("RecordingLeave", {
   group    = macro_group,
   callback = function()
-    macro_reg = ""
-    RedrawScheduler:schedule("status")
+    _macro_display = ""
+    schedule_redraw(REDRAW_STATUS)
   end,
 })
 
 -- === Statusline ===
-vim.o.statusline = "%t %y%h%m%r%=%{v:lua.macro_info()}Ln %l/%L, Col %c%{v:lua.search_info()} %P"
+-- A single %!v:lua.statusline_render() performs one vimscript->Lua bridge
+-- per redraw. The original format string made two separate bridges
+-- (%{v:lua.macro_info()} and %{v:lua.search_info()}) on every evaluation.
+-- search_info logic is inlined here; the _G.search_info global is kept for
+-- external compatibility but is no longer invoked by the statusline itself.
+_G.statusline_render = function()
+  local parts = {}
+
+  -- Left: file name + type flags
+  parts[#parts + 1] = "%t %y%h%m%r"
+
+  -- Right-align separator
+  parts[#parts + 1] = "%="
+
+  -- Macro indicator (pre-computed string; zero allocation on render)
+  if _macro_display ~= "" then
+    parts[#parts + 1] = _macro_display
+  end
+
+  -- Cursor position
+  parts[#parts + 1] = "Ln %l/%L, Col %c"
+
+  -- Search count (cursor-keyed cache; inlined to avoid a second bridge call)
+  if vset.hlsearch == 1 then
+    local pattern = fn.getreg("/")
+    local line    = api.nvim_win_get_cursor(0)[1]
+    local key     = pattern .. "\0" .. line
+    local count   = search_cache:get(key)
+    if not count then
+      local ok, s = pcall(fn.searchcount, _searchcount_opts)
+      count = (ok and s and s.total and s.total > 0)
+              and string.format(" %d/%d", s.current or 0, s.total)
+              or  ""
+      search_cache:set(key, count)
+    end
+    if count ~= "" then parts[#parts + 1] = count end
+  end
+
+  -- Scroll percentage
+  parts[#parts + 1] = " %P"
+
+  return table.concat(parts)
+end
+
+vim.o.statusline = "%!v:lua.statusline_render()"
 
 -- === Clear Highlight ===
 local function clear_hlsearch()
   if vset.hlsearch == 1 then
     cmd("nohlsearch")
-    -- Invalidate only the active pattern; other cached counts remain valid.
-    search_cache:_remove_key(fn.getreg("/"))
+    -- Keys are stored as pattern.."\0"..line, so we must scan for all
+    -- entries whose prefix matches the active pattern. A bare-pattern
+    -- lookup would never hit any key and silently no-op.
+    local prefix = fn.getreg("/") .. "\0"
+    local to_del = {}
+    for k in pairs(search_cache.data) do
+      if k:sub(1, #prefix) == prefix then
+        to_del[#to_del + 1] = k
+      end
+    end
+    for _, k in ipairs(to_del) do search_cache:invalidate(k) end
   end
 end
 
@@ -476,7 +659,7 @@ end, { expr = true, silent = true, noremap = true })
 
 -- === Zen Mode ===
 local zen_state_file  = fn.stdpath("data") .. "/zen_mode_state"
-local zen_state_cache = nil
+local zen_state_cache = nil   -- in-memory cache; avoids repeated disk reads
 
 local ZenMode = {
   active  = false,
@@ -504,12 +687,23 @@ local ZenMode = {
 local _zen_global_opt_set = {}
 for _, k in ipairs(ZenMode.global_opts) do _zen_global_opt_set[k] = true end
 
--- === Async File I/O for Zen State ===
+-- === Zen State Persistence (JSON) ===
+-- JSON format replaces the raw "0"/"1" byte so future fields (e.g., saved
+-- window width, colorscheme override) can be added without a format break.
+-- A legacy fallback in load_zen_state_sync handles existing "1"/"0" files.
+-- Guards against concurrent async writes racing each other. If a write is
+-- already in flight, the newer call is dropped; VimLeavePre always uses the
+-- synchronous variant, so the final state on exit is always correct.
+local _zen_write_inflight = false
+
 local function save_zen_state_async()
   zen_state_cache = ZenMode.active
+  if _zen_write_inflight then return end
+  _zen_write_inflight = true
+  local data = vim.json.encode({ active = ZenMode.active })
   uv.fs_open(zen_state_file, "w", 438, function(err, fd)
+    _zen_write_inflight = false
     if err or not fd then return end
-    local data = ZenMode.active and "1" or "0"
     uv.fs_write(fd, data, 0, function()
       uv.fs_close(fd, function() end)
     end)
@@ -522,31 +716,36 @@ local function save_zen_state_sync()
   zen_state_cache = ZenMode.active
   local fd = uv.fs_open(zen_state_file, "w", 438)
   if not fd then return end
-  uv.fs_write(fd, ZenMode.active and "1" or "0", 0)
+  uv.fs_write(fd, vim.json.encode({ active = ZenMode.active }), 0)
   uv.fs_close(fd)
 end
 
 local function load_zen_state_sync()
   if zen_state_cache ~= nil then return zen_state_cache end
-
   local fd = uv.fs_open(zen_state_file, "r", 438)
   if not fd then zen_state_cache = false; return false end
-
   local stat = uv.fs_fstat(fd)
   if not stat or stat.size == 0 then
     uv.fs_close(fd)
     zen_state_cache = false
     return false
   end
-
-  local data = uv.fs_read(fd, 1, 0)
+  local raw = uv.fs_read(fd, stat.size, 0)
   uv.fs_close(fd)
-  zen_state_cache = (data == "1")
+  local ok, parsed = pcall(vim.json.decode, raw)
+  if ok and type(parsed) == "table" then
+    -- Current JSON format: { active = true/false }
+    zen_state_cache = parsed.active == true
+  else
+    -- Legacy fallback: raw "1" or "0" byte from previous format.
+    zen_state_cache = (raw == "1")
+  end
   return zen_state_cache
 end
 
 -- === Batch Window Operations ===
--- Uses _zen_global_opt_set for correct O(1) dispatch.
+-- nvim_win_is_valid() guard prevents errors when a window closes between
+-- nvim_list_wins() and the inner set loop (e.g., during plugin startup chains).
 local function batch_apply_settings(settings, is_global)
   if is_global then
     for k, v in pairs(settings) do
@@ -557,20 +756,20 @@ local function batch_apply_settings(settings, is_global)
       end
     end
   end
-
-  local wins = api.nvim_list_wins()
-  for _, win in ipairs(wins) do
-    api.nvim_win_call(win, function()
+  for _, win in ipairs(api.nvim_list_wins()) do
+    if api.nvim_win_is_valid(win) then
+      local wopts = { win = win }
       for _, opt_name in ipairs(ZenMode.window_opts) do
-        if settings[opt_name] ~= nil then
-          vim.wo[opt_name] = settings[opt_name]
+        local val = settings[opt_name]
+        if val ~= nil then
+          api.nvim_set_option_value(opt_name, val, wopts)
         end
       end
-    end)
+    end
   end
 end
 
--- === Zen State Snapshot (deduplicated helper) ===
+-- === Zen State Snapshot ===
 local function capture_zen_snapshot()
   return {
     syntax       = vim.o.syntax ~= "off",
@@ -591,8 +790,6 @@ local function capture_zen_snapshot()
 end
 
 -- === Tabline ===
-local tab_cache = Cache:new(5, 200)
-
 function _G.tabline_numbers()
   local current   = fn.tabpagenr()
   local total     = fn.tabpagenr('$')
@@ -601,19 +798,24 @@ function _G.tabline_numbers()
   local cached = tab_cache:get(cache_key)
   if cached then return cached end
 
+  -- Cache miss: enumerate via API to avoid per-tab fn bridges.
+  -- nvim_list_tabpages() is called only here (after the cache check) so the
+  -- table allocation does not occur on cache hits.
+  local tabpages = api.nvim_list_tabpages()
   local parts = {}
-  for i = 1, total do
+  for i, tp in ipairs(tabpages) do
     parts[#parts + 1] = (i == current) and '%#TabLineSel#' or '%#TabLine#'
-    parts[#parts + 1] = ' ' .. tostring(i) .. ' '
+    parts[#parts + 1] = ' ' .. i .. ' '   -- .. coerces int; tostring() unneeded
 
     if not ZenMode.active then
-      local buflist = fn.tabpagebuflist(i)
-      local winnr   = fn.tabpagewinnr(i)
-      local bufnr   = buflist[winnr] or 0
-      if fn.bufexists(bufnr) == 1 then
-        local mod  = (fn.getbufvar(bufnr, '&modified') == 1) and '+' or ''
-        local name = fn.fnamemodify(fn.bufname(bufnr), ':t')
-        name = (name ~= "") and name or '[No Name]'
+      -- nvim_tabpage_get_win + nvim_win_get_buf: 2 API calls instead of
+      -- 2 fn bridges + tabpagebuflist array alloc.
+      local win   = api.nvim_tabpage_get_win(tp)
+      local bufnr = api.nvim_win_get_buf(win)
+      if api.nvim_buf_is_valid(bufnr) then
+        local mod  = vim.bo[bufnr].modified and '+' or ''
+        local name = api.nvim_buf_get_name(bufnr)
+        name = (name ~= "") and fn.fnamemodify(name, ':t') or '[No Name]'
         parts[#parts + 1] = ':' .. name .. mod
       end
     end
@@ -655,7 +857,7 @@ local function toggle_zen_mode()
 
   schedule(function()
     ZenMode._busy = false
-    RedrawScheduler:schedule("tabline")
+    schedule_redraw(REDRAW_TABLINE)
   end)
 end
 
@@ -665,65 +867,86 @@ kset.set("n", "<Space><Space>", toggle_zen_mode, {
   silent  = true,
 })
 
--- === Auto-apply Zen Settings to New Windows ===
-local zen_group         = augroup("ZenModeAuto", { clear = true })
-local zen_apply_pending = false
+-- Export ZenMode before VimEnter so that setup_window() (fired from WinNew)
+-- can read ZenMode.active, ZenMode.window_opts, and ZenMode.config.
+_G.zen_mode = ZenMode
 
-autocmd({ "WinNew", "WinEnter", "BufWinEnter" }, {
-  group    = zen_group,
-  callback = function()
-    if ZenMode.active and not zen_apply_pending then
-      zen_apply_pending = true
-      schedule(function()
-        for _, opt_name in ipairs(ZenMode.window_opts) do
-          if ZenMode.config[opt_name] ~= nil then
-            vim.wo[opt_name] = ZenMode.config[opt_name]
-          end
-        end
-        zen_apply_pending = false
-      end)
-    end
-  end,
-})
-
--- === Restore Zen Mode on Startup ===
+-- === Deferred Initialization ===
+-- Single VimEnter handler with two chained phases replaces the original two
+-- separate handlers at T+100 ms and T+150 ms. Chaining via schedule() makes
+-- the phase-2 dependency on phase-1 explicit and eliminates the implicit
+-- fixed-offset timing assumption.
+--
+-- Phase 1 (T+100 ms): shada load + clipboard.
+-- Phase 2 (one event-loop tick after phase 1 completes): zen restore.
+--
+-- Note on shadafile: Neovim reads shada before VimEnter, so setting
+-- shadafile="" here only blocks future implicit writes. The explicit rshada
+-- call re-reads with the tuned format string — that is the actual intent.
 autocmd("VimEnter", {
   once     = true,
   callback = function()
     defer_fn(function()
-      if load_zen_state_sync() and not ZenMode.active then
-        ZenMode.saved  = capture_zen_snapshot()
-        ZenMode.active = true
-        batch_apply_settings(ZenMode.config, true)
-        api.nvim_set_hl(0, "StatusLine", { bg = "NONE", fg = "#4F5258", bold = false })
-        vim.o.statusline = "%!v:lua.zen_statusline()"
-        schedule(function() RedrawScheduler:schedule("tabline") end)
+      -- Phase 1: shada + clipboard setup.
+      opt.shadafile = ""
+      opt.shada     = "!,'100,<50,s10,h"
+      local shada_path = fn.stdpath("data") .. "/shada/main.shada"
+      -- uv.fs_stat: native Lua equivalent of fn.filereadable(); no vimscript bridge.
+      if uv.fs_stat(shada_path) then
+        pcall(cmd, "silent! rshada")
       end
-    end, 150)
+      opt.clipboard = "unnamedplus"
+
+      -- Phase 2: zen restore chained immediately after phase 1.
+      schedule(function()
+        if load_zen_state_sync() and not ZenMode.active then
+          ZenMode.saved  = capture_zen_snapshot()
+          ZenMode.active = true
+          batch_apply_settings(ZenMode.config, true)
+          api.nvim_set_hl(0, "StatusLine", { bg = "NONE", fg = "#4F5258", bold = false })
+          vim.o.statusline = "%!v:lua.zen_statusline()"
+          schedule(function() schedule_redraw(REDRAW_TABLINE) end)
+        end
+      end)
+    end, 100)
   end,
 })
 
 -- === Unified VimLeavePre Cleanup ===
--- Consolidates zen state persistence and timer teardown into one autocmd.
+-- _shutting_down is set before timers are closed so that in-flight
+-- schedule() callbacks (cursor debounce, redraw) cannot restart closed handles.
 autocmd("VimLeavePre", {
   once     = true,
   callback = function()
+    _shutting_down = true
     save_zen_state_sync()
     for _, t in pairs(Timers) do
-      if t:is_active() then t:stop() end
-      t:close()
+      -- is_closing() is safe on any handle state; prevents double-close errors.
+      if not t:is_closing() then
+        if t:is_active() then t:stop() end
+        t:close()
+      end
     end
   end,
 })
 
 -- === Memory Management ===
+-- run_gc has its own minimum-gap guard (5 s) so that rapid FocusLost events
+-- (e.g., alt-tabbing quickly) do not iterate all three caches every time.
+-- The heavier collectgarbage() full cycle keeps its separate 10 s cooldown.
+local _gc_last_run   = 0
+local _gc_min_gap_ms = 5000
+local _gc_cooldown   = false
+
 local function run_gc()
+  local now = uv.now()
+  if (now - _gc_last_run) < _gc_min_gap_ms then return end
+  _gc_last_run = now
   search_cache:gc()
   syntax_cache:gc()
   tab_cache:gc()
 end
 
-local _gc_cooldown = false
 autocmd("FocusLost", {
   callback = function()
     run_gc()
@@ -732,28 +955,33 @@ autocmd("FocusLost", {
       defer_fn(function()
         collectgarbage("collect")
         _gc_cooldown = false
-      end, 10000)  -- 10s cooldown between forced GC cycles
+      end, 10000)  -- 10 s cooldown between forced full GC cycles
     end
   end,
 })
 
 -- === Periodic Cache GC (static timer, no reallocation) ===
-Timers.gc:start(300000, 300000, function()
+gc_timer:start(300000, 300000, function()
   schedule(run_gc)
 end)
 
 -- === CursorMoved Debounce ===
+-- Both callbacks are module-level functions (pre-allocated once at load time).
+-- Without this, every CursorMoved event allocates 2 closures immediately
+-- discarded on the next movement (e.g. holding an arrow key).
+local function _cursor_redraw()
+  if vset.hlsearch == 1 then
+    schedule_redraw(REDRAW_STATUS)
+  end
+end
+local function _cursor_timer_cb()
+  schedule(_cursor_redraw)
+end
+
 autocmd("CursorMoved", {
   callback = function()
-    Timers.cursor:stop()
-    Timers.cursor:start(100, 0, function()
-      schedule(function()
-        if vset.hlsearch == 1 then
-          RedrawScheduler:schedule("status")
-        end
-      end)
-    end)
+    if _shutting_down then return end   -- do not restart a closed timer
+    cursor_timer:stop()
+    cursor_timer:start(100, 0, _cursor_timer_cb)
   end,
 })
-
-_G.zen_mode = ZenMode


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body>
<hr>
<h2>Changelog</h2>
<h3>Breaking / Compatibility</h3>
<ul>
<li><strong>Neovim 0.12+ required.</strong> The minimum version has been bumped from 0.11 to 0.12.</li>
<li><strong>Zen state file format changed to JSON.</strong> The persisted zen state is now written as <code>{"active":true/false}</code> instead of a raw <code>"1"</code>/<code>"0"</code> byte. A legacy fallback in <code>load_zen_state_sync</code> handles existing files transparently, so no manual migration is needed.</li>
<li><strong><code>RedrawScheduler:schedule()</code> replaced by <code>schedule_redraw(flags)</code>.</strong> Call sites now pass bitmask constants (<code>REDRAW_TABLINE</code>, <code>REDRAW_STATUS</code>, <code>REDRAW_FULL</code>).</li>
</ul>
<hr>
<h3>New Features</h3>
<ul>
<li><strong>Statusline</strong> (<code>_G.statusline_render</code>): A unified statusline renderer is now set via a single <code>%!v:lua.statusline_render()</code> bridge, replacing the two-bridge pattern (<code>%{v:lua.macro_info()}</code> + <code>%{v:lua.search_info()}</code>). Displays filename, file type flags, macro indicator, cursor position, search count, and scroll percentage.</li>
<li><strong>Macro recording indicator</strong> (<code>_G.macro_info</code>): <code>RecordingEnter</code>/<code>RecordingLeave</code> autocmds now pre-compute a display string (<code>" REC @x "</code>) once per session rather than on every statusline render, costing zero string allocations during playback.</li>
<li><strong>Buffer cleaner</strong> (<code>clean_buffer</code>): A <code>BufWritePre</code> hook that trims trailing whitespace and expands tabs to spaces in a single batched <code>nvim_buf_set_lines</code> pass. Module-scope scratch state (<code>_cb_ranges</code>, <code>_cb_run_lines</code>) is reused across calls to avoid per-save allocations. Skips non-modifiable, unmodified, and very large buffers (&gt;50,000 lines).</li>
<li><strong>Deferred shada + clipboard init</strong>: <code>VimEnter</code> now also handles deferred shada loading (<code>opt.shada</code>, <code>silent! rshada</code>) and sets <code>clipboard = "unnamedplus"</code> in phase 1, before zen restore in phase 2.</li>
</ul>
<hr>
<h3>Bug Fixes</h3>
<ul>
<li><strong>Cache <code>#</code> on sparse arrays (silent correctness bug):</strong> <code>_order_len</code> is now tracked explicitly. The old code used <code>#self.order</code> after <code>_remove_key</code> left interior <code>nil</code> holes, which makes Lua's <code>#</code> return an undefined "border" value. Eviction and compaction thresholds now use <code>_order_len</code> instead.</li>
<li><strong>Search count stale after cursor movement:</strong> The search cache key now includes the cursor line (<code>pattern .. "\0" .. line</code>). Previously, keying on pattern alone returned a stale <code>current</code> index (e.g., "3/10") after moving the cursor within the same search session.</li>
<li><strong>Syntax <code>synmaxcol</code> set in wrong direction for heavy files:</strong> Was <code>300</code> (wider than the global <code>200</code>), now corrected to <code>120</code> for large heavy files.</li>
<li><strong><code>clear_hlsearch</code> cache miss:</strong> The old call <code>search_cache:_remove_key(fn.getreg("/"))</code> used the bare pattern as a key, which never matched anything once the cache key format included the cursor line. Now scans and invalidates all keys sharing the active pattern prefix.</li>
<li><strong>Double-close on timer teardown:</strong> <code>VimLeavePre</code> now guards each timer with <code>t:is_closing()</code> before stopping/closing to prevent errors when a timer was already in the closing state.</li>
<li><strong>Window option apply race in <code>batch_apply_settings</code>:</strong> Now validates each window with <code>api.nvim_win_is_valid()</code> before applying options, guarding against windows closed between <code>nvim_list_wins()</code> and the inner loop.</li>
<li><strong>Conflicting window setup handlers:</strong> The old <code>apply_win_defaults</code> + separate zen <code>WinNew/WinEnter/BufWinEnter</code> handlers could race. Replaced by a single <code>setup_window()</code> that applies base defaults and then layers zen overrides atomically. Also adds an <code>nvim_win_is_valid</code> close-race guard.</li>
<li><strong>In-flight <code>schedule()</code> callbacks restarting closed timers:</strong> A <code>_shutting_down</code> flag is set in <code>VimLeavePre</code> before teardown. All timer start sites (<code>schedule_redraw</code>, <code>CursorMoved</code>) check this flag before restarting a handle.</li>
</ul>
<hr>
<h3>Performance Improvements</h3>
<ul>
<li><strong>Plugin/provider disabling:</strong> Replaced two loops with runtime string concatenation (<code>'loaded_' .. plugin</code>) with a single flat <code>_g_flags</code> table using compile-time constant keys, eliminating ~16 string allocations at startup.</li>
<li><strong>Options applied in a single batch loop:</strong> All <code>vim.opt</code> assignments are now applied in one table-driven <code>for</code> loop, avoiding 34 individual metatable dispatches.</li>
<li><strong>Redraw scheduler rewritten as a bitmask:</strong> <code>RedrawScheduler</code> (table with <code>pending</code> hash, method dispatch) replaced by a plain integer <code>_redraw_pending</code> accumulated with LuaJIT's <code>bit.bor</code>. Eliminates a <code>pending</code> table allocation and method dispatch overhead on every redraw cycle.</li>
<li><strong>Timer callbacks pre-allocated:</strong> <code>_redraw_timer_cb</code> and <code>_cursor_timer_cb</code> / <code>_cursor_redraw</code> are now module-level functions. The old <code>CursorMoved</code> handler created two fresh closures per event (e.g., every arrow-key repeat), all immediately discarded.</li>
<li><strong>Tabline uses nvim API instead of vimscript bridges:</strong> <code>tabpagebuflist()</code>, <code>tabpagewinnr()</code>, <code>bufname()</code>, <code>getbufvar()</code>, and <code>bufexists()</code> replaced with <code>nvim_list_tabpages()</code>, <code>nvim_tabpage_get_win()</code>, <code>nvim_win_get_buf()</code>, <code>vim.bo[bufnr].modified</code>, <code>nvim_buf_get_name()</code>, and <code>nvim_buf_is_valid()</code>.</li>
<li><strong>FileType cache key uses <code>"\0"</code> separator:</strong> Prevents ambiguous matches (e.g., <code>ft="lua5"</code> + <code>buf=""</code> vs <code>ft="lua"</code> + <code>buf=5</code>).</li>
<li><strong><code>_compact()</code> rewritten in-place:</strong> Clears stale trailing slots without allocating a replacement array. <code>gc()</code> loop also simplified.</li>
<li><strong><code>run_gc()</code> has a 5-second minimum-gap guard:</strong> Prevents rapid <code>FocusLost</code> events (e.g., fast alt-tabbing) from iterating all three caches on every event.</li>
<li><strong><code>_searchcount_opts</code> hoisted to module scope:</strong> Avoids one table allocation per <code>search_info</code> cache miss.</li>
<li><strong><code>ts_get_parser</code> localized:</strong> <code>vim.treesitter.get_parser</code> is stored in a local to avoid repeated global-chain lookups on every <code>FileType</code> event.</li>
<li><strong><code>ColorScheme</code> callback deferred via <code>schedule()</code>:</strong> Ensures highlight overrides run after all events in a colorscheme's load sequence, not just after the first one.</li>
</ul>
<hr>
<h3>API Updates (Neovim 0.12)</h3>
<ul>
<li><code>vim.lsp.set_log_level</code> (deprecated in 0.12) → <code>vim.lsp.log.set_level</code>.</li>
<li><code>vim.wo[opt_name] = v</code> → <code>api.nvim_set_option_value(opt_name, val, { win = win })</code> throughout <code>batch_apply_settings</code> and <code>setup_window</code>.</li>
</ul>
<hr>
<h3>New Options</h3>

Option | Value | Notes
-- | -- | --
pumheight | 10 | Caps completion menu height to prevent layout thrash
splitkeep | "screen" | Reduces layout shifts on split (0.9+)
jumpoptions | "stack" | Browser-history-style jump list
fileencodings | "ucs-bom,utf-8,default,latin1" | BOM detection + wider fallback chain
fileformats | "unix,dos,mac" | Explicit line-ending detection order
shortmess append | "sI" | Suppresses intro screen and search-wrap messages
undolevels | 1000 (was 200) | Deeper undo history
clipboard | "unnamedplus" | Set deferred in VimEnter phase 1


<hr>
<h3>Other</h3>
<ul>
<li><strong>Arrow keys disabled in insert and operator-pending modes</strong> in addition to normal and visual, to enforce consistent <code>hjkl</code> habits.</li>
<li><strong><code>syntax_fast</code> / <code>syntax_heavy</code> sets expanded</strong> with modern filetypes: <code>tsx</code>, <code>jsx</code>, <code>go</code>, <code>rust</code>, <code>zig</code>, <code>ruby</code>, <code>php</code>, <code>swift</code>, <code>h</code>, <code>hpp</code> (fast); <code>toml</code>, <code>html</code>, <code>css</code>, <code>scss</code>, <code>xml</code> (heavy).</li>
<li><strong><code>BufDelete</code> / <code>BufWipeout</code> autocmd added</strong> to evict <code>syntax_cache</code> entries when a buffer is deleted or wiped, preventing false cache hits if the buffer number is immediately reused.</li>
<li><strong><code>Cache:invalidate()</code> added</strong> as a public alias for <code>_remove_key()</code>, so external callers don't depend on the internal name.</li>
<li><strong><code>VimEnter</code> handlers consolidated</strong> from two separate handlers at T+100ms and T+150ms into a single handler with explicit phase chaining via <code>schedule()</code>, making the phase-2 dependency on phase-1 explicit.</li>
<li><strong><code>_G.zen_mode</code> exported earlier</strong> (before <code>VimEnter</code>) so <code>setup_window()</code> can read <code>ZenMode.active</code> when fired from <code>WinNew</code> during startup.</li>
<li><strong><code>_zen_write_inflight</code> guard</strong> prevents a concurrent async zen-state write from racing a prior in-flight write; the synchronous <code>VimLeavePre</code> path is unaffected.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>